### PR TITLE
fix typo in Eyes.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eyes.selenium",
-    "version": "0.0.58",
+    "version": "0.0.59",
     "description": "Applitools Eyes SDK For Selenium JavaScript WebDriver",
     "author": "Applitools Team <team@applitools.com> (http://www.applitools.com/)",
     "keywords": [

--- a/src/Eyes.js
+++ b/src/Eyes.js
@@ -108,10 +108,10 @@
         var that = this;
 
         if (typeof protractor !== 'undefined') {
-            that._isProtratorLoaded = true;
+            that._isProtractorLoaded = true;
             that._logger.verbose("Running using Protractor module");
         } else {
-            that._isProtratorLoaded = false;
+            that._isProtractorLoaded = false;
             that._logger.verbose("Running using Selenium module");
         }
 
@@ -167,7 +167,7 @@
                     that._driver = new EyesWebDriver(driver, that, that._logger, that._promiseFactory);
 
                     // extend protractor element to return ours
-                    if (that._isProtratorLoaded) {
+                    if (that._isProtractorLoaded) {
                         var originalElementFn = global.element;
                         global.element = function (locator) {
                             return new ElementFinderWrapper(originalElementFn(locator), that._driver, that._logger);


### PR DESCRIPTION
there was a typo in this file, `protactor` instead of `protractor`