### PR TITLE
recognize wedriver.WebElements correctly

### DIFF
--- a/src/Eyes.js
+++ b/src/Eyes.js
@@ -419,7 +419,7 @@
     };
 
     var isElementObject = function (o) {
-        return o instanceof EyesRemoteWebElement;
+        return (o instanceof EyesRemoteWebElement || o instanceof webdriver.WebElement);
     };
 
     var isLocatorObject = function (o) {


### PR DESCRIPTION
This needs to be merged for `eyes.checkRegionByElement` and similar functions to work. Otherwise, trying to do this:
```js
yield eyes.checkElementByRegion(someWebdriverWebElement), 'some tag');
```

raises an error:
```
 Error {
    message: 'Unsupported region type: object',
  }
```
     
One further note: this commit looks like what broke it, so if there was a reason there perhaps you have more context than I do:
https://github.com/ttdmayshark/Eyes.Selenium.JavaScript/commit/d20dabe9ab6cc6b77201f15e3c21eee10e6be4b3#diff-5a3ba2410ee7605d890a1b491c9ad788L418